### PR TITLE
Refactor provider service to standardize service category and city to…

### DIFF
--- a/src/main/java/com/nukkadseva/nukkadsevabackend/service/implementation/ProviderServiceImpl.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/service/implementation/ProviderServiceImpl.java
@@ -85,13 +85,13 @@ public class ProviderServiceImpl implements ProviderService{
         provider.setMobileNumber(providerDto.getMobileNumber());
         provider.setEmail(providerDto.getEmail());
         provider.setBusinessName(providerDto.getBusinessName());
-        provider.setServiceCategory(providerDto.getServiceCategory());
+        provider.setServiceCategory(providerDto.getServiceCategory().toUpperCase());
         provider.setServiceArea(providerDto.getServiceArea());
         provider.setExperience(providerDto.getExperience());
         provider.setLanguages(providerDto.getLanguages());
         provider.setFullAddress(providerDto.getFullAddress());
         provider.setState(providerDto.getState());
-        provider.setCity(providerDto.getCity());
+        provider.setCity(providerDto.getCity().toUpperCase());
         provider.setPincode(providerDto.getPincode());
         provider.setGstin(providerDto.getGstin());
         provider.setBio(providerDto.getBio());


### PR DESCRIPTION
This pull request introduces a small but important change to the provider registration logic, ensuring consistency in how certain fields are stored.

* The `serviceCategory` and `city` fields are now converted to uppercase before being saved in the `Provider` entity, which helps maintain uniform data formatting for these attributes.