### PR TITLE
Add Booking entity and related enums for booking management

### DIFF
--- a/src/main/java/com/nukkadseva/nukkadsevabackend/entity/Booking.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/entity/Booking.java
@@ -1,0 +1,90 @@
+package com.nukkadseva.nukkadsevabackend.entity;
+
+import com.nukkadseva.nukkadsevabackend.entity.enums.BookingStatus;
+import com.nukkadseva.nukkadsevabackend.entity.enums.PaymentMethod;
+import com.nukkadseva.nukkadsevabackend.entity.enums.PaymentStatus;
+import com.nukkadseva.nukkadsevabackend.entity.enums.Services;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@DynamicUpdate
+@Entity
+@Table(
+        name = "booking",
+        indexes = {
+                @Index(name = "idx_booking_customer", columnList = "customer_id"),
+                @Index(name = "idx_booking_provider", columnList = "provider_id"),
+                @Index(name = "idx_booking_status", columnList = "status"),
+                @Index(name = "idx_booking_date", columnList = "booking_date_time"),
+                @Index(name = "idx_booking_review", columnList = "review_id")
+        }
+)
+public class Booking {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "booking_id", nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private Customers customer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "provider_id", nullable = false)
+    private Provider provider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "service_type", nullable = false)
+    private Services serviceType;
+
+    @Column(name = "booking_date_time", nullable = false)
+    private LocalDateTime bookingDateTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BookingStatus status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+        private LocalDateTime updatedAt;
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "estimate_price")
+        private BigDecimal priceEstimate;
+    @Column(name = "final_price")
+    private BigDecimal finalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_status")
+    private PaymentStatus paymentStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_method")
+    private PaymentMethod paymentMethod;
+
+    @Column(name = "note", columnDefinition = "TEXT")
+        private String note;
+    @Column(name = "provider_notes", columnDefinition = "TEXT")
+    private String providerNote;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "review_id", unique = true)
+    private Review review;
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/entity/Review.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/entity/Review.java
@@ -1,15 +1,6 @@
 package com.nukkadseva.nukkadsevabackend.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Table;
-import jakarta.persistence.Index;
-import jakarta.persistence.Id;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.Getter;
@@ -21,7 +12,6 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Entity
-// Add indexes for foreign keys for better query performance
 @Table(name = "reviews", indexes = {
         @Index(name = "idx_reviews_customer_id", columnList = "customer_id"),
         @Index(name = "idx_reviews_provider_id", columnList = "provider_id")
@@ -55,4 +45,7 @@ public class Review {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @OneToOne(mappedBy = "review")
+    private Booking booking;
 }

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/entity/enums/BookingStatus.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/entity/enums/BookingStatus.java
@@ -1,0 +1,10 @@
+package com.nukkadseva.nukkadsevabackend.entity.enums;
+
+public enum BookingStatus {
+    PENDING,
+    APPROVED,
+    COMPLETED,
+    REJECTED,
+    DATE_UPDATED,
+    TIME_UPDATED
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/entity/enums/PaymentMethod.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/entity/enums/PaymentMethod.java
@@ -1,0 +1,18 @@
+package com.nukkadseva.nukkadsevabackend.entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum PaymentMethod {
+    CREDIT_CARD("Credit Card"),
+    DEBIT_CARD("Debit Card"),
+    NET_BANKING("Net Banking"),
+    UPI("UPI"),
+    CASH_AFTER_SERVICE("Cash After Service");
+
+    private final String displayName;
+
+    PaymentMethod(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/entity/enums/PaymentStatus.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/entity/enums/PaymentStatus.java
@@ -1,0 +1,9 @@
+package com.nukkadseva.nukkadsevabackend.entity.enums;
+
+public enum PaymentStatus {
+    PENDING,
+    COMPLETED,
+    FAILED,
+    CANCELLED,
+    REFUNDED
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/entity/enums/Services.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/entity/enums/Services.java
@@ -1,0 +1,21 @@
+package com.nukkadseva.nukkadsevabackend.entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Services {
+    PLUMBING("Plumbing"),
+    CLEANING("Cleaning"),
+    ELECTRICAL("Electrical"),
+    PAINTING("Painting"),
+    REPAIRS("Repairs"),
+    APPLIANCE_REPAIRS("Appliance Repairs"),
+    CARPENTRY("Carpentry"),
+    COOKING_SERVICES("Cooking Services");
+
+    private final String displayName;
+
+    Services(String displayName) {
+        this.displayName = displayName;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `Booking` entity to the backend, along with supporting enums for booking status, payment methods, payment status, and service types. It also enhances the `Review` entity to establish a bidirectional relationship with bookings. These changes lay the groundwork for managing bookings, payments, and reviews in the application.

### Booking Entity and Relationships

* Added the `Booking` entity (`Booking.java`) with fields for customer, provider, service type, booking date/time, status, timestamps, pricing, payment details, notes, and a link to reviews. Includes JPA annotations for table definition and indexes to optimize queries.
* Established a bidirectional one-to-one relationship between `Booking` and `Review`, allowing each booking to be associated with a review and vice versa. [[1]](diffhunk://#diff-62fb1eac33abc614a195b2a4d82b6b09f347515de70414b77bfbf3a0a6f6c13aR1-R90) [[2]](diffhunk://#diff-7452e78e40b8a7cf692e6cd593124ac09f8ee1e455bc39fab5e0981f95590a88R48-R50)

### Supporting Enums

* Introduced enums for `BookingStatus`, `PaymentMethod` (with display names), `PaymentStatus`, and `Services` (with display names) to standardize values used in bookings. [[1]](diffhunk://#diff-7e5e195ed6aaa67dee2b7e3f3300ee347b2e89cf5707e94dfa476199f559dcaaR1-R10) [[2]](diffhunk://#diff-51950771a696851f568cf5d9e355a58a960bba54ed6f344014ed095896fc8ccdR1-R18) [[3]](diffhunk://#diff-a030c70313504406ec7a3f4a8b42877c04f92dbeba2d2dab2e81e0ae231fa4d6R1-R9) [[4]](diffhunk://#diff-5daadddd75ae7bb4ddedd0f10a63673566e4d09e3703dea651eb5a87fea6f55eR1-R21)

### Review Entity Improvements

* Updated the `Review` entity to use a single import for JPA annotations and clarified table indexes for better query performance. [[1]](diffhunk://#diff-7452e78e40b8a7cf692e6cd593124ac09f8ee1e455bc39fab5e0981f95590a88L3-R3) [[2]](diffhunk://#diff-7452e78e40b8a7cf692e6cd593124ac09f8ee1e455bc39fab5e0981f95590a88L24)