### PR TITLE
forget password is now implemented

### DIFF
--- a/src/main/java/com/nukkadseva/nukkadsevabackend/config/SecurityConfig.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                                                                                 "/api/public/**",
                                                                                 "/api/services/search",
                                                                                 "/api/logout",
+                                                                                "/api/forgot-password",
+                                                                                "/api/reset-password",
                                                                                 "/api/provider/verify-email",
                                                                                 "/api/verify-email",
                                                                                 "/ws/**",

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/controller/UserController.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/controller/UserController.java
@@ -14,6 +14,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import com.nukkadseva.nukkadsevabackend.dto.ApiResponse;
+import com.nukkadseva.nukkadsevabackend.dto.request.ForgotPasswordRequest;
+import com.nukkadseva.nukkadsevabackend.dto.request.ResetPasswordRequest;
 import com.nukkadseva.nukkadsevabackend.dto.request.UserRequest;
 import com.nukkadseva.nukkadsevabackend.dto.response.AuthResponse;
 import com.nukkadseva.nukkadsevabackend.service.UserService;
@@ -77,6 +79,19 @@ public class UserController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(response);
+    }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<ApiResponse> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
+        userService.generateResetOtp(request);
+        return ResponseEntity.ok(new ApiResponse("OTP_SENT", "If the email is registered, an OTP has been sent."));
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponse> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        userService.resetPassword(request);
+        return ResponseEntity
+                .ok(new ApiResponse("PASSWORD_RESET_SUCCESS", "Your password has been reset successfully."));
     }
 
     @PutMapping("/update-profile-picture")

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/dto/request/ForgotPasswordRequest.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/dto/request/ForgotPasswordRequest.java
@@ -1,0 +1,14 @@
+package com.nukkadseva.nukkadsevabackend.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ForgotPasswordRequest {
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    private String email;
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,20 @@
+package com.nukkadseva.nukkadsevabackend.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResetPasswordRequest {
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    private String email;
+
+    @NotBlank(message = "OTP is required")
+    private String otp;
+
+    @NotBlank(message = "New password is required")
+    private String newPassword;
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/service/EmailService.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/service/EmailService.java
@@ -1,0 +1,5 @@
+package com.nukkadseva.nukkadsevabackend.service;
+
+public interface EmailService {
+    void sendForgotPasswordOtpEmail(String to, String name, String otp);
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/service/UserService.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/service/UserService.java
@@ -5,8 +5,17 @@ import com.nukkadseva.nukkadsevabackend.dto.response.AuthResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.nukkadseva.nukkadsevabackend.dto.request.ForgotPasswordRequest;
+import com.nukkadseva.nukkadsevabackend.dto.request.ResetPasswordRequest;
+
 public interface UserService {
     AuthResponse login(UserRequest userRequest);
+
     boolean verifyEmail(String token);
+
     void updateProfilePicture(MultipartFile file, Authentication authentication);
+
+    void generateResetOtp(ForgotPasswordRequest request);
+
+    void resetPassword(ResetPasswordRequest request);
 }

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/service/implementation/EmailServiceImpl.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/service/implementation/EmailServiceImpl.java
@@ -1,0 +1,50 @@
+package com.nukkadseva.nukkadsevabackend.service.implementation;
+
+import com.nukkadseva.nukkadsevabackend.service.EmailService;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender mailSender;
+    private final Configuration freemarkerConfiguration;
+
+    @Override
+    public void sendForgotPasswordOtpEmail(String to, String name, String otp) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            Map<String, Object> templateModel = new HashMap<>();
+            templateModel.put("name", name);
+            templateModel.put("otp", otp);
+
+            Template template = freemarkerConfiguration.getTemplate("forgot-password-otp.html");
+            String htmlBody = FreeMarkerTemplateUtils.processTemplateIntoString(template, templateModel);
+
+            helper.setTo(to);
+            helper.setSubject("Password Reset Request - NukkadSeva");
+            helper.setText(htmlBody, true);
+
+            mailSender.send(message);
+            log.info("Forgot password OTP email sent successfully to {}", to);
+
+        } catch (Exception e) {
+            log.error("Failed to send forgot password email to {}", to, e);
+            throw new RuntimeException("Failed to send email");
+        }
+    }
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/service/implementation/UserServiceImpl.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/service/implementation/UserServiceImpl.java
@@ -7,11 +7,15 @@ import com.nukkadseva.nukkadsevabackend.dto.response.AuthResponse;
 import com.nukkadseva.nukkadsevabackend.entity.Customers;
 import com.nukkadseva.nukkadsevabackend.entity.Provider;
 import com.nukkadseva.nukkadsevabackend.repository.ProviderRepository;
+import com.nukkadseva.nukkadsevabackend.dto.request.ForgotPasswordRequest;
+import com.nukkadseva.nukkadsevabackend.dto.request.ResetPasswordRequest;
+import com.nukkadseva.nukkadsevabackend.service.EmailService;
 import com.nukkadseva.nukkadsevabackend.service.AzureBlobStorageService;
 import com.nukkadseva.nukkadsevabackend.service.UserService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.authentication.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -22,6 +26,8 @@ import org.springframework.stereotype.Service;
 import com.nukkadseva.nukkadsevabackend.dto.request.UserRequest;
 import com.nukkadseva.nukkadsevabackend.entity.Users;
 import com.nukkadseva.nukkadsevabackend.exception.UserAuthenticationException;
+import com.nukkadseva.nukkadsevabackend.exception.CustomerNotFoundException;
+import com.nukkadseva.nukkadsevabackend.exception.InvalidOtpException;
 import com.nukkadseva.nukkadsevabackend.security.JwtUtil;
 import com.nukkadseva.nukkadsevabackend.repository.CustomerRepository;
 import com.nukkadseva.nukkadsevabackend.repository.UserRepository;
@@ -40,6 +46,8 @@ public class UserServiceImpl implements UserService {
     private final ProviderRepository providerRepository;
     private final JwtUtil jwtUtil;
     private final AzureBlobStorageService azureBlobStorageService;
+    private final EmailService emailService;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public AuthResponse login(UserRequest userRequest) {
@@ -148,5 +156,58 @@ public class UserServiceImpl implements UserService {
             default:
                 throw new IllegalArgumentException("Unsupported role: " + role);
         }
+    }
+
+    @Override
+    @Transactional
+    public void generateResetOtp(ForgotPasswordRequest request) {
+        Optional<Users> userOpt = userRepository.findByEmail(request.getEmail());
+        if (userOpt.isEmpty()) {
+            throw new CustomerNotFoundException("No account found with this email address.");
+        }
+
+        Users user = userOpt.get();
+
+        if (!user.isVerified()) {
+            throw new CustomerNotFoundException(
+                    "This account has not been verified yet. Please verify your email first.");
+        }
+
+        // Generate 6-digit OTP
+        String otp = String.format("%06d", new java.util.Random().nextInt(999999));
+
+        user.setVerificationToken(otp);
+        user.setTokenExpiresAt(LocalDateTime.now().plusMinutes(15));
+        userRepository.save(user);
+
+        // Get user's name for email if available
+        String name = "User";
+        if (user.getCustomers() != null && user.getCustomers().getFullName() != null) {
+            name = user.getCustomers().getFullName();
+        } else if (user.getProvider() != null && user.getProvider().getFullName() != null) {
+            name = user.getProvider().getFullName();
+        }
+
+        emailService.sendForgotPasswordOtpEmail(user.getEmail(), name, otp);
+    }
+
+    @Override
+    @Transactional
+    public void resetPassword(ResetPasswordRequest request) {
+        Users user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new CustomerNotFoundException("No account found with this email address."));
+
+        if (user.getVerificationToken() == null || !user.getVerificationToken().equals(request.getOtp())) {
+            throw new InvalidOtpException("The OTP you entered is incorrect. Please try again.");
+        }
+
+        if (user.getTokenExpiresAt() == null || user.getTokenExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new InvalidOtpException("This OTP has expired. Please request a new one.");
+        }
+
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        user.setVerificationToken(null);
+        user.setTokenExpiresAt(null);
+        userRepository.save(user);
     }
 }

--- a/src/main/resources/templates/forgot-password-otp.html
+++ b/src/main/resources/templates/forgot-password-otp.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Reset Your Password</title>
+    <style>
+        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f4f7f6; margin: 0; padding: 0; }
+        .container { max-width: 600px; margin: 40px auto; background-color: #ffffff; padding: 40px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.05); }
+        h1 { color: #333333; font-size: 24px; margin-bottom: 20px; }
+        p { color: #555555; font-size: 16px; line-height: 1.6; margin-bottom: 20px; }
+        .otp-box { background-color: #f8f9fa; border: 2px dashed #007bff; color: #007bff; padding: 15px 30px; font-size: 32px; font-weight: bold; letter-spacing: 5px; text-align: center; border-radius: 8px; margin: 30px 0; display: inline-block; }
+        .footer { margin-top: 40px; text-align: center; font-size: 14px; color: #999999; border-top: 1px solid #eeeeee; padding-top: 20px; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Password Reset Request</h1>
+    <p>Hi ${name},</p>
+    <p>We received a request to reset the password for your NukkadSeva account. Use the OTP below to set a new password:</p>
+    
+    <div style="text-align: center;">
+        <div class="otp-box">${otp}</div>
+    </div>
+    
+    <p>This OTP is valid for <strong>15 minutes</strong>. If you did not request a password reset, please ignore this email or contact support if you have concerns.</p>
+    
+    <div class="footer">
+        <p>Best regards,<br>The NukkadSeva Team</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a complete password reset feature, allowing users to request an OTP for password reset and securely update their password using the OTP sent via email. The changes span API endpoints, DTOs, service interfaces and implementations, and email templating.

**Password Reset Feature**

* Added two new API endpoints: `/api/forgot-password` for requesting a password reset OTP, and `/api/reset-password` for resetting the password using the OTP. [[1]](diffhunk://#diff-7475ed2eaaf35e891394a188e4832adea7c6027e3bc8a7a1b8d3ca0de4e8f188R57-R58) [[2]](diffhunk://#diff-a2b226a02151140fa71840571a098667e4e5118b52fc73e6791c6e242f174ee0R84-R96)
* Introduced `ForgotPasswordRequest` and `ResetPasswordRequest` DTOs for validating incoming requests. [[1]](diffhunk://#diff-7051069a5a8531a76952520550ba1402dfc9601f2e758e45f9eeebe3d8836c45R1-R14) [[2]](diffhunk://#diff-51602902ce8ecf5af103d2d0a4b25cc3db8d74cf532770255de83a752f37f0b2R1-R20)

**Service Layer Enhancements**

* Updated `UserService` interface and implemented logic in `UserServiceImpl` to handle OTP generation, email sending, and password reset, including validation and error handling for expired or invalid OTPs. [[1]](diffhunk://#diff-a263f8c735f810a1d154554f67f045de508626220499fba85326cc11cdb0bae8R8-R20) [[2]](diffhunk://#diff-c172cc6d5d6d387e830c089b3e87d8213770b41104b81c882d2fe779206c8c6aR160-R212)
* Added `EmailService` interface and its implementation (`EmailServiceImpl`) to send OTP emails using a FreeMarker template. [[1]](diffhunk://#diff-f43e90bfe7013d070a66186e88a42dd1aa638d1a5a58149d848f756e7ea9b8abR1-R5) [[2]](diffhunk://#diff-0d369d215012c1f0cc47b5fed880beb00677ca2091af5f0a55830b2b612fcec0R1-R50)

**Email Template**

* Added a styled HTML email template (`forgot-password-otp.html`) for sending OTPs to users.

**Dependency and Exception Handling**

* Integrated new dependencies and custom exceptions for improved error handling during password reset operations. [[1]](diffhunk://#diff-c172cc6d5d6d387e830c089b3e87d8213770b41104b81c882d2fe779206c8c6aR29-R30) [[2]](diffhunk://#diff-c172cc6d5d6d387e830c089b3e87d8213770b41104b81c882d2fe779206c8c6aR49-R50) [[3]](diffhunk://#diff-c172cc6d5d6d387e830c089b3e87d8213770b41104b81c882d2fe779206c8c6aR10-R18)