### PR TITLE
Provider not showing bug is resolved.

### DIFF
--- a/src/main/java/com/nukkadseva/nukkadsevabackend/controller/AdminController.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/controller/AdminController.java
@@ -106,6 +106,11 @@ public class AdminController {
 
     // ============ City Management Endpoints ============
 
+    @GetMapping("/cities")
+    public ResponseEntity<List<CityWithPincodesResponse>> getAllCities() {
+        return ResponseEntity.ok(cityService.getAllCitiesWithPincodes());
+    }
+
     @PostMapping("/cities")
     public ResponseEntity<?> addCityWithPincodes(@Valid @RequestBody CityWithPincodesRequest request) {
         try {

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/controller/ServiceController.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/controller/ServiceController.java
@@ -2,7 +2,7 @@ package com.nukkadseva.nukkadsevabackend.controller;
 
 import com.nukkadseva.nukkadsevabackend.dto.request.ServiceDto;
 import com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto;
-import com.nukkadseva.nukkadsevabackend.entity.ProviderServiceItem;
+import com.nukkadseva.nukkadsevabackend.dto.response.ServiceSearchResultDto;
 import com.nukkadseva.nukkadsevabackend.service.ProviderServiceItemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.Data;
-import lombok.Builder;
-
 @RestController
 @RequestMapping("/api/services")
 @RequiredArgsConstructor
@@ -54,45 +49,13 @@ public class ServiceController {
         return ResponseEntity.ok(updatedService);
     }
 
-    @Data
-    @Builder
-    public static class ServiceSearchResultDto {
-        private Long id;
-        private String name;
-        private String description;
-        private String category;
-        private BigDecimal price;
-        private Integer durationMinutes;
-        private String providerName;
-        private Long providerId;
-        private List<String> pincodes;
-        private boolean providerVerified;
-    }
-
     @GetMapping("/search")
     public ResponseEntity<List<ServiceSearchResultDto>> searchServices(
             @RequestParam(required = false) String city,
             @RequestParam(required = false) String pincode,
             @RequestParam(required = false) Long providerId) {
 
-        List<ProviderServiceItem> services = serviceItemService.searchServices(city, pincode, providerId);
-
-        List<ServiceSearchResultDto> results = services.stream()
-                .map((ProviderServiceItem service) -> ServiceSearchResultDto.builder()
-                        .id(service.getId())
-                        .name(service.getName())
-                        .description(service.getDescription())
-                        .category(service.getCategory())
-                        .price(service.getPrice())
-                        .durationMinutes(service.getDurationMinutes())
-                        .providerName(service.getProvider().getFullName())
-                        .providerId(service.getProvider().getId())
-                        .pincodes(service.getProvider().getProviderAreas().stream()
-                                .flatMap(area -> area.getPincodes().stream()).collect(Collectors.toList()))
-                        .providerVerified(Boolean.TRUE.equals(service.getProvider().getIsApproved()))
-                        .build())
-                .collect(Collectors.toList());
-
+        List<ServiceSearchResultDto> results = serviceItemService.searchServices(city, pincode, providerId);
         return ResponseEntity.ok(results);
     }
 }

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/controller/ServiceController.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/controller/ServiceController.java
@@ -1,6 +1,7 @@
 package com.nukkadseva.nukkadsevabackend.controller;
 
 import com.nukkadseva.nukkadsevabackend.dto.request.ServiceDto;
+import com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto;
 import com.nukkadseva.nukkadsevabackend.entity.ProviderServiceItem;
 import com.nukkadseva.nukkadsevabackend.service.ProviderServiceItemService;
 import jakarta.validation.Valid;
@@ -26,29 +27,29 @@ public class ServiceController {
 
     @PreAuthorize("hasRole('SERVICE_PROVIDER')")
     @PostMapping
-    public ResponseEntity<com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto> createService(
+    public ResponseEntity<ProviderServiceItemResponseDto> createService(
             @Valid @RequestBody ServiceDto serviceDto,
             Authentication authentication) {
-        com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto createdService = serviceItemService
+        ProviderServiceItemResponseDto createdService = serviceItemService
                 .createService(serviceDto, authentication);
         return new ResponseEntity<>(createdService, HttpStatus.CREATED);
     }
 
     @PreAuthorize("hasRole('SERVICE_PROVIDER')")
     @GetMapping("/me")
-    public ResponseEntity<List<com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto>> getMyServices(
+    public ResponseEntity<List<ProviderServiceItemResponseDto>> getMyServices(
             Authentication authentication) {
-        List<com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto> myServices = serviceItemService
+        List<ProviderServiceItemResponseDto> myServices = serviceItemService
                 .getMyServices(authentication);
         return ResponseEntity.ok(myServices);
     }
 
     @PreAuthorize("hasRole('SERVICE_PROVIDER')")
     @PatchMapping("/{id}/toggle-status")
-    public ResponseEntity<com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto> toggleServiceStatus(
+    public ResponseEntity<ProviderServiceItemResponseDto> toggleServiceStatus(
             @PathVariable Long id,
             Authentication authentication) {
-        com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto updatedService = serviceItemService
+        ProviderServiceItemResponseDto updatedService = serviceItemService
                 .toggleServiceStatus(id, authentication);
         return ResponseEntity.ok(updatedService);
     }

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/dto/response/ServiceSearchResultDto.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/dto/response/ServiceSearchResultDto.java
@@ -1,0 +1,22 @@
+package com.nukkadseva.nukkadsevabackend.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@Builder
+public class ServiceSearchResultDto {
+    private Long id;
+    private String name;
+    private String description;
+    private String category;
+    private BigDecimal price;
+    private Integer durationMinutes;
+    private String providerName;
+    private Long providerId;
+    private List<String> pincodes;
+    private boolean providerVerified;
+}

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/repository/ProviderServiceItemRepository.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/repository/ProviderServiceItemRepository.java
@@ -3,6 +3,8 @@ package com.nukkadseva.nukkadsevabackend.repository;
 import com.nukkadseva.nukkadsevabackend.entity.Provider;
 import com.nukkadseva.nukkadsevabackend.entity.ProviderServiceItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,14 +13,14 @@ import java.util.List;
 public interface ProviderServiceItemRepository extends JpaRepository<ProviderServiceItem, Long> {
         List<ProviderServiceItem> findByProvider(Provider provider);
 
-        @org.springframework.data.jpa.repository.Query("SELECT DISTINCT s FROM ProviderServiceItem s JOIN s.provider p LEFT JOIN p.providerAreas a "
+        @Query("SELECT DISTINCT s FROM ProviderServiceItem s JOIN s.provider p LEFT JOIN p.providerAreas a "
                         +
-                        "WHERE p.status = 'APPROVED' AND s.isActive = true " +
+                        "WHERE p.status = com.nukkadseva.nukkadsevabackend.entity.enums.ProviderStatus.APPROVED AND s.isActive = true " +
                         "AND (:city IS NULL OR a.city = :city OR p.city = :city) " +
-                        "AND (:pincode IS NULL OR p.serviceArea LIKE %:pincode% OR :pincode IN elements(a.pincodes)) " +
+                        "AND (:pincode IS NULL OR p.serviceArea LIKE CONCAT('%', :pincode, '%') OR :pincode MEMBER OF a.pincodes) " +
                         "AND (:providerId IS NULL OR p.id = :providerId)")
         List<ProviderServiceItem> searchServices(
-                        @org.springframework.data.repository.query.Param("city") String city,
-                        @org.springframework.data.repository.query.Param("pincode") String pincode,
-                        @org.springframework.data.repository.query.Param("providerId") Long providerId);
+                        @Param("city") String city,
+                        @Param("pincode") String pincode,
+                        @Param("providerId") Long providerId);
 }

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/service/ProviderServiceItemService.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/service/ProviderServiceItemService.java
@@ -1,11 +1,11 @@
 package com.nukkadseva.nukkadsevabackend.service;
 
 import com.nukkadseva.nukkadsevabackend.dto.request.ServiceDto;
-import com.nukkadseva.nukkadsevabackend.entity.ProviderServiceItem;
 import org.springframework.security.core.Authentication;
 
 import java.util.List;
 
+import com.nukkadseva.nukkadsevabackend.dto.response.ServiceSearchResultDto;
 import com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto;
 
 public interface ProviderServiceItemService {
@@ -13,7 +13,7 @@ public interface ProviderServiceItemService {
 
     List<ProviderServiceItemResponseDto> getMyServices(Authentication authentication);
 
-    List<ProviderServiceItem> searchServices(String city, String pincode, Long providerId);
+    List<ServiceSearchResultDto> searchServices(String city, String pincode, Long providerId);
 
     ProviderServiceItemResponseDto toggleServiceStatus(Long serviceId, Authentication authentication);
 }

--- a/src/main/java/com/nukkadseva/nukkadsevabackend/service/implementation/ProviderServiceItemServiceImpl.java
+++ b/src/main/java/com/nukkadseva/nukkadsevabackend/service/implementation/ProviderServiceItemServiceImpl.java
@@ -2,6 +2,7 @@ package com.nukkadseva.nukkadsevabackend.service.implementation;
 
 import com.nukkadseva.nukkadsevabackend.dto.request.ServiceDto;
 import com.nukkadseva.nukkadsevabackend.dto.response.ProviderServiceItemResponseDto;
+import com.nukkadseva.nukkadsevabackend.dto.response.ServiceSearchResultDto;
 import com.nukkadseva.nukkadsevabackend.entity.Provider;
 import com.nukkadseva.nukkadsevabackend.entity.ProviderServiceItem;
 import com.nukkadseva.nukkadsevabackend.exception.ProviderNotFoundException;
@@ -55,8 +56,25 @@ public class ProviderServiceItemServiceImpl implements ProviderServiceItemServic
     }
 
     @Override
-    public List<ProviderServiceItem> searchServices(String city, String pincode, Long providerId) {
-        return serviceItemRepository.searchServices(city, pincode, providerId);
+    @Transactional(readOnly = true)
+    public List<ServiceSearchResultDto> searchServices(String city, String pincode, Long providerId) {
+        List<ProviderServiceItem> services = serviceItemRepository.searchServices(city, pincode, providerId);
+
+        return services.stream()
+                .map((ProviderServiceItem service) -> ServiceSearchResultDto.builder()
+                        .id(service.getId())
+                        .name(service.getName())
+                        .description(service.getDescription())
+                        .category(service.getCategory())
+                        .price(service.getPrice())
+                        .durationMinutes(service.getDurationMinutes())
+                        .providerName(service.getProvider().getFullName())
+                        .providerId(service.getProvider().getId())
+                        .pincodes(service.getProvider().getProviderAreas().stream()
+                                .flatMap(area -> area.getPincodes().stream()).collect(Collectors.toList()))
+                        .providerVerified(Boolean.TRUE.equals(service.getProvider().getIsApproved()))
+                        .build())
+                .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
This pull request primarily refactors and improves type usage and query clarity in the service-related backend code. The main focus is on simplifying type references in the `ServiceController` and enhancing the JPA query in the `ProviderServiceItemRepository` for better readability and correctness.

**Controller type simplification:**

* Replaces fully qualified type names for `ProviderServiceItemResponseDto` in `ServiceController` with direct imports and simplified usage, making the code cleaner and easier to read. [[1]](diffhunk://#diff-d16f9b5d61b2c7ae4500412a1a10373b686a5511826cc575b90ad59619e186b9R4) [[2]](diffhunk://#diff-d16f9b5d61b2c7ae4500412a1a10373b686a5511826cc575b90ad59619e186b9L29-R52)

**Repository query improvements:**

* Updates the JPA query in `ProviderServiceItemRepository` to reference the `ProviderStatus.APPROVED` enum directly, improving type safety and clarity. Also changes string concatenation and collection membership checks for the `pincode` filter to use `CONCAT` and `MEMBER OF` for better compatibility and correctness. [[1]](diffhunk://#diff-894f0545d55c592e4ce2858673b74b8a7f379562270b01f54016d90254537cccR6-R7) [[2]](diffhunk://#diff-894f0545d55c592e4ce2858673b74b8a7f379562270b01f54016d90254537cccL14-R25)